### PR TITLE
deleted relative path

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
  module.exports = {
      entry: './src/main.js',
      output: {
-         path: './dist',
+         path: '/dist',
          filename: 'bundle.js'
      }
  };


### PR DESCRIPTION
Webpack throws an error saying that it requires absolute paths otherwise.